### PR TITLE
Log to stderr

### DIFF
--- a/ModestMaps/__init__.py
+++ b/ModestMaps/__init__.py
@@ -221,7 +221,7 @@ def printlocked(lock, *stuff):
     """
     """
     if lock.acquire():
-        print ' '.join([str(thing) for thing in stuff])
+        print >> sys.stderr, ' '.join([str(thing) for thing in stuff])
         lock.release()
 
 class TileRequest:


### PR DESCRIPTION
Not writing to stderr causes problems (the presence of unexpected data) when binaries are output on stdout (and `verbose=True`).